### PR TITLE
Rust pipeline + maajor version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+
 jobs:
   release:
     name: Release
@@ -12,27 +13,64 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0
         with:
-          node-version: "lts/*"
-      - name: Install dependencies
-        run: npm ci
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm run release
-      - name: Get release
-        id: get_release
-        run: echo "NEXT_VERSION=$(npm run package-version --silent)" >> $GITHUB_OUTPUT
+          versionSpec: '5.12.0'
+
+      - name: Create GitVersion.yml
+        run: |
+          cat <<EOF > GitVersion.yml
+          assembly-versioning-scheme: MajorMinorPatch
+          assembly-file-versioning-scheme: MajorMinorPatch
+          assembly-informational-format: '{InformationalVersion}'
+          mode: Mainline
+          increment: Inherit
+          continuous-delivery-fallback-tag: ci
+          tag-prefix: '[vV]'
+          major-version-bump-message: '(breaking|major|incompatible):'
+          minor-version-bump-message: '(feature|minor|enhancement|new|update|improvement|upgrade|feat):'
+          patch-version-bump-message: '(fix|patch|bugfix|hotfix|correction|adjustment|tweak):'
+          no-bump-message: '(none|skip|no-release|trivial|docs|documentation|style|refactor|chore|test):'
+          legacy-semver-padding: 4
+          build-metadata-padding: 4
+          commits-since-version-source-padding: 4
+          tag-pre-release-weight: 60000
+          commit-message-incrementing: Enabled
+          merge-message-formats: {}
+          update-build-number: true
+          EOF
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0
+        with:
+          useConfigFile: true
+
+      - name: Update version in Cargo.toml
+        run: |
+          sed -i 's|^version = ".*"|version = "${{ env.semVer }}"|' Cargo.toml
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Push docker image release
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: cnieg/secret-certificat-azure-exporter:${{ steps.get_release.outputs.NEXT_VERSION }}
+          tags: cnieg/secret-certificat-azure-exporter:${{ env.semVer }}
+
+      - name: Update Cargo.lock
+        uses: moonrepo/setup-rust@v1
+      - run: cargo check
+
+      - name: add and commit Cargo.* files
+        uses: EndBug/add-and-commit@v9.1.4
+        with:
+          add: 'Cargo.*'
+          message: 'skip: release ${{ env.semVer }} [skip ci]'
+          tag: '${{ env.semVer }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.0](https://github.com/cnieg/secret-certificat-azure-exporter/compare/1.0.4...2.0.0) (2024-03-11)
+
+* Rewrite in Rust
+
 ## [1.0.4](https://github.com/cnieg/secret-certificat-azure-exporter/compare/1.0.3...1.0.4) (2023-05-31)
 
 


### PR DESCRIPTION
The 'release' pipeline has been rewritten to support the new rust code.

The PR will also create a new major version for this project (the docker image tag will be '2.0.0')